### PR TITLE
RDKB-58443 RDKB-58446 Add WPA3-Compatibility Configuration and Teleme…

### DIFF
--- a/src/wifi_hal.c
+++ b/src/wifi_hal.c
@@ -2492,6 +2492,9 @@ static int decode_bss_info_to_neighbor_ap_info(wifi_neighbor_ap2_t *ap, const wi
         case wifi_security_mode_wpa3_enterprise:
             str = "WPA3-Enterprise";
             break;
+        case wifi_security_mode_wpa3_compatibility:
+            str = "WPA3-Compatibility";
+            break;
         default:
             str = "?";
     }
@@ -3849,6 +3852,20 @@ void wifi_hal_apDisassociatedDevice_callback_register(wifi_apDisassociatedDevice
 
     callbacks->disassoc_cb[callbacks->num_disassoc_cbs] = func;
     callbacks->num_disassoc_cbs++;
+}
+
+void wifi_hal_stamode_callback_register(wifi_stamode_callback func)
+{
+    wifi_device_callbacks_t *callbacks;
+
+    callbacks = get_hal_device_callbacks();
+
+    if (callbacks == NULL || callbacks->num_stamode_cbs> MAX_REGISTERED_CB_NUM) {
+        return;
+    }
+
+    callbacks->stamode_cb[callbacks->num_stamode_cbs] = func;
+    callbacks->num_stamode_cbs++;
 }
 
 void wifi_hal_radius_eap_failure_callback_register(wifi_radiusEapFailure_callback func)

--- a/src/wifi_hal_hostapd.c
+++ b/src/wifi_hal_hostapd.c
@@ -481,6 +481,9 @@ int update_security_config(wifi_vap_security_t *sec, struct hostapd_bss_config *
 
     conf->ieee802_1x = 0;
     conf->wpa_key_mgmt = 0;
+#if HOSTAPD_VERSION == 210
+    conf->wpa_key_mgmt_rsno = 0;
+#endif
     conf->wpa = 0;
     memset(&test_ip, 0, sizeof(test_ip));
 
@@ -546,6 +549,16 @@ int update_security_config(wifi_vap_security_t *sec, struct hostapd_bss_config *
 #endif /* CONFIG_IEEE80211BE*/
 #endif
             break;
+        case wifi_security_mode_wpa3_compatibility:
+            conf->wpa_key_mgmt = WPA_KEY_MGMT_PSK;
+#if HOSTAPD_VERSION == 210
+            conf->wpa_key_mgmt_rsno = WPA_KEY_MGMT_SAE;
+            conf->sae_pwe = 1; /* 0 = Hunt-and-Peck, 1 = Hash-to-Element, 2 = both */
+#endif
+            if( is_wifi_hal_6g_radio_from_interfacename(conf->iface) == true ) {
+                conf->wpa_key_mgmt = WPA_KEY_MGMT_SAE;
+            }
+            break;
         default:
             conf->wpa_key_mgmt = -1;
             break;
@@ -595,6 +608,16 @@ int update_security_config(wifi_vap_security_t *sec, struct hostapd_bss_config *
             conf->sae_require_mfp = 0;
             break;
     }
+    if(sec->mode == wifi_security_mode_wpa3_compatibility) {
+        conf->ieee80211w = (enum mfp_options) NO_MGMT_FRAME_PROTECTION;
+#if HOSTAPD_VERSION == 210
+        conf->ieee80211w_rsno = (enum mfp_options) MGMT_FRAME_PROTECTION_REQUIRED;
+#endif
+        conf->sae_require_mfp = 1;
+        if( is_wifi_hal_6g_radio_from_interfacename(conf->iface) == true ) {
+            conf->ieee80211w = (enum mfp_options) MGMT_FRAME_PROTECTION_REQUIRED;
+        }
+    }
 #endif
 
     wifi_hal_dbg_print("%s:%d: security:%d mfp:%d wpa_key_mgmt:%d 11w:%d\n",
@@ -617,6 +640,7 @@ int update_security_config(wifi_vap_security_t *sec, struct hostapd_bss_config *
         case wifi_security_mode_wpa3_enterprise:
         case wifi_security_mode_wpa3_transition:
         case wifi_security_mode_enhanced_open:
+        case wifi_security_mode_wpa3_compatibility:
             conf->wpa = 2;
             break;
 
@@ -648,6 +672,7 @@ int update_security_config(wifi_vap_security_t *sec, struct hostapd_bss_config *
             case wifi_security_mode_wpa3_personal:
             case wifi_security_mode_wpa3_transition:
             case wifi_security_mode_wpa3_enterprise:
+            case wifi_security_mode_wpa3_compatibility:
                 conf->wpa_pairwise |= (conf->disable_11be ? 0 : WPA_CIPHER_GCMP_256);
                 break;
             default:
@@ -670,7 +695,7 @@ int update_security_config(wifi_vap_security_t *sec, struct hostapd_bss_config *
     conf->wpa_group_rekey = sec->rekey_interval;
     conf->wpa_group_rekey_set = 1;
 
-    wifi_hal_dbg_print("%s:%d: wpa_gmk_rekey:%d wpa_group_rekey:%d\n", __func__, __LINE__, conf->wpa_gmk_rekey, conf->wpa_group_rekey);
+    wifi_hal_dbg_print("%s:%d: wpa_gmk_rekey:%d wpa_group_rekey:%d wpa:%d \n", __func__, __LINE__, conf->wpa_gmk_rekey, conf->wpa_group_rekey, conf->wpa);
 
     conf->wpa_strict_rekey = sec->strict_rekey;
 
@@ -2477,7 +2502,7 @@ void update_wpa_sm_params(wifi_interface_info_t *interface)
         ctx->cancel_auth_timeout = wpa_sm_sta_cancel_auth_timeout;
 #ifdef CONFIG_WIFI_EMULATOR
         if((sec->mode == wifi_security_mode_wpa3_personal) || (sec->mode == wifi_security_mode_wpa3_enterprise) ||
-                (sec->mode == wifi_security_mode_wpa3_transition)) {
+                (sec->mode == wifi_security_mode_wpa3_transition) || (sec->mode == wifi_security_mode_wpa3_compatibility)) {
             ctx->get_state = wpa_sm_supplicant_sta_get_state;
             ctx->cancel_auth_timeout = wpa_sm_supplicant_sta_cancel_auth_timeout;
         }
@@ -2596,6 +2621,8 @@ void update_wpa_sm_params(wifi_interface_info_t *interface)
                 sel = (WPA_KEY_MGMT_SAE | wpa_key_mgmt_11w);
             } else if (sec->mode == wifi_security_mode_wpa3_enterprise) {
                 sel = (WPA_KEY_MGMT_IEEE8021X_SHA256 | wpa_key_mgmt_11w);
+            } else if (sec->mode == wifi_security_mode_wpa3_compatibility) {
+                sel = (WPA_KEY_MGMT_PSK | WPA_KEY_MGMT_SAE);
             } else {
                 wifi_hal_error_print("Unsupported security mode : 0x%x\n", sec->mode);
                 return;

--- a/src/wifi_hal_hostapd.c
+++ b/src/wifi_hal_hostapd.c
@@ -552,12 +552,15 @@ int update_security_config(wifi_vap_security_t *sec, struct hostapd_bss_config *
         case wifi_security_mode_wpa3_compatibility:
             conf->wpa_key_mgmt = WPA_KEY_MGMT_PSK;
 #if HOSTAPD_VERSION == 210
-            conf->wpa_key_mgmt_rsno = WPA_KEY_MGMT_SAE;
-            conf->sae_pwe = 1; /* 0 = Hunt-and-Peck, 1 = Hash-to-Element, 2 = both */
+            if( is_wifi_hal_6g_radio_from_interfacename(conf->iface) == false ) {
+                conf->wpa_key_mgmt_rsno = WPA_KEY_MGMT_SAE;
+                conf->sae_pwe = 1; /* 0 = Hunt-and-Peck, 1 = Hash-to-Element, 2 = both */
+            }
 #endif
             if( is_wifi_hal_6g_radio_from_interfacename(conf->iface) == true ) {
                 conf->wpa_key_mgmt = WPA_KEY_MGMT_SAE;
             }
+            conf->auth_algs = WPA_AUTH_ALG_SAE | WPA_AUTH_ALG_SHARED | WPA_AUTH_ALG_OPEN;
             break;
         default:
             conf->wpa_key_mgmt = -1;

--- a/src/wifi_hal_nl80211.c
+++ b/src/wifi_hal_nl80211.c
@@ -8274,7 +8274,8 @@ int nl80211_connect_sta(wifi_interface_info_t *interface)
     memset(interface->wpa_s.current_ssid->ssid, 0, (strlen(backhaul->ssid) + 1));
     strcpy(interface->wpa_s.current_ssid->ssid, backhaul->ssid);
     if ((security->mode != wifi_security_mode_wpa2_personal) &&
-            (security->mode != wifi_security_mode_wpa3_transition)) {
+            (security->mode != wifi_security_mode_wpa3_transition) &&
+            (security->mode != wifi_security_mode_wpa3_compatibility)) {
         interface->wpa_s.current_ssid->ssid_len = strlen(backhaul->ssid);
     }
     interface->wpa_s.current_bss->freq = backhaul->freq;
@@ -8384,6 +8385,12 @@ int nl80211_connect_sta(wifi_interface_info_t *interface)
                     break;
                 case wifi_security_mode_wpa3_transition:
                     wpa_conf.wpa_key_mgmt = WPA_KEY_MGMT_PSK | WPA_KEY_MGMT_SAE;
+                    break;
+                case wifi_security_mode_wpa3_compatibility:
+                    wpa_conf.wpa_key_mgmt = WPA_KEY_MGMT_PSK;
+#if HOSTAPD_VERSION == 210
+                    wpa_conf.wpa_key_mgmt_rsno = WPA_KEY_MGMT_SAE;
+#endif
                     break;
                 default:
                     wifi_hal_info_print("%s:%d:Invalid security mode: %d in wifi_hal_connect\r\n", __func__, __LINE__, security->mode);
@@ -14045,7 +14052,8 @@ int wifi_supplicant_drv_authenticate(void *priv, struct wpa_driver_auth_params *
     nla_put_u32(msg, NL80211_ATTR_WIPHY_FREQ, params->freq);
 
     if ((security->mode == wifi_security_mode_wpa3_personal) ||
-        (security->mode == wifi_security_mode_wpa3_transition)) {
+        (security->mode == wifi_security_mode_wpa3_transition) ||
+        (security->mode == wifi_security_mode_wpa3_compatibility)) {
         nla_put(msg, NL80211_ATTR_SAE_DATA, params->auth_data_len, params->auth_data);
         nla_put_u32(msg, NL80211_ATTR_AUTH_TYPE, NL80211_AUTHTYPE_SAE);
     } else {
@@ -16033,6 +16041,56 @@ INT wifi_hal_getRadioTransmitPower(INT radioIndex, ULONG *tx_power)
     return RETURN_OK;
 }
 
+int wifi_drv_get_sta_auth_type(void *priv, const u8 *addr, int auth_key,int frame_type)
+{
+    wifi_interface_info_t *interface;
+    wifi_vap_info_t *vap;
+    mac_address_t sta;
+    mac_addr_str_t  sta_mac_str;
+    wifi_device_callbacks_t *callbacks;
+    int band;
+    int key_mgmt;
+    if(!addr || !priv) {
+        wifi_hal_error_print("%s:%d station/ies info is null\n", __func__, __LINE__);
+        return RETURN_ERR;
+    }
+    if (auth_key == WPA_KEY_MGMT_PSK) {
+        key_mgmt = 2;
+    }
+    else if (auth_key == WPA_KEY_MGMT_SAE) {
+        key_mgmt = 8;
+    }
+    else if (auth_key == 67108864) {
+        key_mgmt = 24;
+    }
+    else {
+        key_mgmt = -1;
+    }
+    interface = (wifi_interface_info_t *)priv;
+
+    if(interface == NULL) {
+        wifi_hal_error_print("%s:%d interface is null\n", __func__, __LINE__);
+        return RETURN_ERR;
+    }
+
+    vap = &interface->vap_info;
+    memcpy(sta, addr, sizeof(mac_address_t));
+    band = vap->radio_index;
+    callbacks = get_hal_device_callbacks();
+
+    if (callbacks == NULL) {
+        return -1;
+    }
+
+    for (int i = 0; i < callbacks->num_stamode_cbs; i++) {
+        if (callbacks->stamode_cb[i] != NULL) {
+            callbacks->stamode_cb[i](vap->vap_index, to_mac_str(sta, sta_mac_str),key_mgmt,frame_type,band);
+        }
+    }
+
+    return RETURN_OK;
+}
+
 const struct wpa_driver_ops g_wpa_driver_nl80211_ops = {
     .name = "nl80211",
     .desc = "Linux nl80211/cfg80211",
@@ -16194,6 +16252,9 @@ const struct wpa_driver_ops g_wpa_driver_nl80211_ops = {
 #endif // CONFIG_VENDOR_COMMANDS
 #ifdef CMXB7_PORT
     .set_chan_dfs_state = nl80211_set_channel_dfs_state,
+#endif
+#if HOSTAPD_VERSION == 210
+    .get_sta_auth_type = wifi_drv_get_sta_auth_type,
 #endif
 #if HOSTAPD_VERSION >= 210 // 2.10
     .get_rnr_colocation_len = wifi_drv_get_rnr_colocation_len,
@@ -16358,6 +16419,9 @@ const struct wpa_driver_ops g_wpa_supplicant_driver_nl80211_ops = {
     .radius_fallback_failover = wifi_drv_send_radius_fallback_and_failover,
 #ifdef CMXB7_PORT
     .set_chan_dfs_state = nl80211_set_channel_dfs_state,
+#endif
+#if HOSTAPD_VERSION == 210
+    .get_sta_auth_type = wifi_drv_get_sta_auth_type,
 #endif
 };
 #endif //CONFIG_WIFI_EMULATOR

--- a/src/wifi_hal_nl80211.c
+++ b/src/wifi_hal_nl80211.c
@@ -16050,6 +16050,7 @@ int wifi_drv_get_sta_auth_type(void *priv, const u8 *addr, int auth_key,int fram
     wifi_device_callbacks_t *callbacks;
     int band;
     int key_mgmt;
+    wifi_hal_dbg_print("%s:%d started \n", __func__, __LINE__);
     if(!addr || !priv) {
         wifi_hal_error_print("%s:%d station/ies info is null\n", __func__, __LINE__);
         return RETURN_ERR;
@@ -16084,10 +16085,11 @@ int wifi_drv_get_sta_auth_type(void *priv, const u8 *addr, int auth_key,int fram
 
     for (int i = 0; i < callbacks->num_stamode_cbs; i++) {
         if (callbacks->stamode_cb[i] != NULL) {
+	    wifi_hal_dbg_print("%s:%d called \n", __func__, __LINE__);
             callbacks->stamode_cb[i](vap->vap_index, to_mac_str(sta, sta_mac_str),key_mgmt,frame_type,band);
         }
     }
-
+    wifi_hal_dbg_print("%s:%d done \n", __func__, __LINE__);
     return RETURN_OK;
 }
 
@@ -16253,7 +16255,7 @@ const struct wpa_driver_ops g_wpa_driver_nl80211_ops = {
 #ifdef CMXB7_PORT
     .set_chan_dfs_state = nl80211_set_channel_dfs_state,
 #endif
-#if HOSTAPD_VERSION == 210
+#if HOSTAPD_VERSION >= 210
     .get_sta_auth_type = wifi_drv_get_sta_auth_type,
 #endif
 #if HOSTAPD_VERSION >= 210 // 2.10
@@ -16420,7 +16422,7 @@ const struct wpa_driver_ops g_wpa_supplicant_driver_nl80211_ops = {
 #ifdef CMXB7_PORT
     .set_chan_dfs_state = nl80211_set_channel_dfs_state,
 #endif
-#if HOSTAPD_VERSION == 210
+#if HOSTAPD_VERSION >= 210
     .get_sta_auth_type = wifi_drv_get_sta_auth_type,
 #endif
 };

--- a/src/wifi_hal_nl80211.c
+++ b/src/wifi_hal_nl80211.c
@@ -16061,7 +16061,7 @@ int wifi_drv_get_sta_auth_type(void *priv, const u8 *addr, int auth_key,int fram
     else if (auth_key == WPA_KEY_MGMT_SAE) {
         key_mgmt = 8;
     }
-    else if (auth_key == 67108864) {
+    else if (auth_key == WPA_KEY_MGMT_SAE_EXT_KEY) {
         key_mgmt = 24;
     }
     else {

--- a/src/wifi_hal_nl80211_utils.c
+++ b/src/wifi_hal_nl80211_utils.c
@@ -1785,6 +1785,8 @@ int get_security_mode_int_from_str(char *security_mode_str,char *mfp_str,wifi_se
         *security_mode = wifi_security_mode_wpa3_enterprise;
     } else if (strcmp(security_mode_str, "wpa wpa2") == 0) {
         *security_mode = wifi_security_mode_wpa_wpa2_enterprise;
+    } else if (strstr(security_mode_str, "psk2") && strstr(security_mode_str, "sae") && !strcmp(mfp_str, "0")) {
+        *security_mode = wifi_security_mode_wpa3_compatibility;
     } else {
         wifi_hal_error_print("%s:%d: wifi security mode not found:[%s:%s]\r\n",__func__, __LINE__, security_mode_str,mfp_str);
         return RETURN_ERR;
@@ -1875,6 +1877,26 @@ int get_security_mode_str_from_int(wifi_security_modes_t security_mode, unsigned
         strcpy(security_mode_str, "wpa wpa2");
         break;
 
+    case wifi_security_mode_wpa3_compatibility:
+#ifdef CONFIG_IEEE80211BE
+        {
+            const wifi_interface_info_t * const interface = get_interface_by_vap_index(vap_index);
+            if (NULL == interface) {
+                wifi_hal_error_print("%s:%d NULL pointer!\n", __FUNCTION__, __LINE__);
+                return RETURN_ERR;
+            }
+            if (wifi_vap_mode_ap == interface->vap_info.vap_mode &&
+                !interface->u.ap.conf.disable_11be) {
+                strcpy(security_mode_str, "sae sae-ext psk2");
+            } else {
+                strcpy(security_mode_str, "psk2 sae");
+            }
+        }
+#else
+        strcpy(security_mode_str, "psk2 sae");
+#endif
+        break;
+
     default:
         wifi_hal_error_print("%s:%d: wifi security mode not found:[%d]\r\n",__func__, __LINE__, security_mode);
         return RETURN_ERR;
@@ -1907,6 +1929,7 @@ int get_security_encryption_mode_str_from_int(wifi_encryption_method_t encryptio
                 case wifi_security_mode_wpa3_personal:
                 case wifi_security_mode_wpa3_transition:
                 case wifi_security_mode_wpa3_enterprise:
+                case wifi_security_mode_wpa3_compatibility:
                     has_gcmp256 = !interface->u.ap.conf.disable_11be;
                     break;
                 default:

--- a/src/wifi_hal_priv.h
+++ b/src/wifi_hal_priv.h
@@ -803,6 +803,7 @@ INT wifi_hal_configNeighborReports(UINT apIndex, bool enable, bool auto_resp);
 INT wifi_hal_setNeighborReports(UINT apIndex, UINT numNeighborReports, wifi_NeighborReport_t *neighborReports);
 void wifi_hal_newApAssociatedDevice_callback_register(wifi_newApAssociatedDevice_callback func);
 void wifi_hal_apDisassociatedDevice_callback_register(wifi_apDisassociatedDevice_callback func);
+void wifi_hal_stamode_callback_register(wifi_stamode_callback func);
 void wifi_hal_radiusEapFailure_callback_register(wifi_radiusEapFailure_callback func);
 void wifi_hal_radiusFallback_failover_callback_register(wifi_radiusFallback_failover_callback func);
 void wifi_hal_apDeAuthEvent_callback_register(wifi_apDeAuthEvent_callback func);

--- a/src/wifi_hal_rdk_framework.h
+++ b/src/wifi_hal_rdk_framework.h
@@ -133,6 +133,8 @@ typedef struct {
     unsigned int                            num_radius_fallback_failover_cbs;
     wifi_radiusFallback_failover_callback   radius_failover_fallback_cbs[MAX_REGISTERED_CB_NUM];
     unsigned int                            num_vapstatus_cbs;
+    unsigned int                            num_stamode_cbs;
+    wifi_stamode_callback                   stamode_cb[MAX_REGISTERED_CB_NUM];
     queue_t                                 *queue;
     wifi_RMBeaconReport_callback            bcnrpt_callback[MAX_AP_INDEX];
     wifi_BTM_callbacks_t                    btm_callback[MAX_AP_INDEX];

--- a/src/wifi_hal_rdk_util.c
+++ b/src/wifi_hal_rdk_util.c
@@ -363,7 +363,7 @@ int validate_wifi_interface_vap_info_params(wifi_vap_info_t *vap_info, char *msg
     }
 
     // security parameter values
-    if (bss_info->security.mode <= 0 || bss_info->security.mode > wifi_security_mode_enhanced_open ||
+    if (bss_info->security.mode <= 0 || bss_info->security.mode >  wifi_security_mode_wpa3_compatibility ||
             (bss_info->security.mode &(bss_info->security.mode - 1)) != 0) {
         ret = RETURN_ERR;
         snprintf(msg + strlen(msg), len - strlen(msg), " security mode: %d", bss_info->security.mode);


### PR DESCRIPTION
…try Impacted Platforms: XB7, XB8

Reason for change: To add WPA3-Personal-Compatibility in OneWiFi

Test Procedure: Enable WPA3-Compatibility RFC and set security mode as WPA3-Personal-Compatibility.
Check Client connectivity and internet

Risks: Medium
Priority:P1

Signed-off-by:Amalesh_Nandh@comcast.com
Signed-off-by:Harshavardhan_Pulluru@comcast.com